### PR TITLE
Refine KeyboardEvent Typescript definition

### DIFF
--- a/packages/hooks/lib/useDay/useDay.d.ts
+++ b/packages/hooks/lib/useDay/useDay.d.ts
@@ -30,7 +30,7 @@ declare function useDay({
   isSelectedStartOrEnd: boolean
   isWithinHoverRange: boolean
   disabledDate: boolean
-  onKeyDown: (e: KeyboardEvent) => void
+  onKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void
   onClick: () => void
   onMouseEnter: () => void
 }


### PR DESCRIPTION
Without specifying the exact DOM element for `KeyboardEvent` Typescipt throws an error:
```
Type '(e: KeyboardEvent) => void' is not assignable to type '(event: KeyboardEvent<HTMLButtonElement>) => void'.
```

This PR aims to fix that.