### PR TITLE
provide option to keep month selection on startDate select

### DIFF
--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -82,6 +82,10 @@ Initial visible month
 
 If `isDateBlocked` returns `true`, then the date is blocked.
 
+#### `changeActiveMonthOnSelect?: boolean`
+
+If this is false, the active month panel will not change when selecting the start date.
+
 ### `unavailableDates?: Date[]`
 
 Receives unavailable dates in array.

--- a/packages/hooks/src/useDatepicker/useDatepicker.ts
+++ b/packages/hooks/src/useDatepicker/useDatepicker.ts
@@ -45,6 +45,7 @@ export interface UseDatepickerProps {
   initialVisibleMonth?: Date
   isDateBlocked?(date: Date): boolean
   unavailableDates?: Date[]
+  changeActiveMonthOnSelect?: boolean
 }
 
 export function useDatepicker({
@@ -61,6 +62,7 @@ export function useDatepicker({
   firstDayOfWeek = 1,
   isDateBlocked: isDateBlockedProps = () => false,
   unavailableDates = [],
+  changeActiveMonthOnSelect = true,
 }: UseDatepickerProps) {
   const [activeMonths, setActiveMonths] = useState(() =>
     startDate
@@ -73,15 +75,15 @@ export function useDatepicker({
   useEffect(() => {
     if (typeof window !== 'undefined') {
       if (window.addEventListener) {
-         window.addEventListener('keydown', handleKeyDown)
+        window.addEventListener('keydown', handleKeyDown)
       }
     }
-   
-      return () => {
-        if (window.removeEventListener) {
-          window.removeEventListener('keydown', handleKeyDown)
-        }
+
+    return () => {
+      if (window.removeEventListener) {
+        window.removeEventListener('keydown', handleKeyDown)
       }
+    }
   })
 
   const disabledDatesByUser = (date: Date) => {
@@ -228,7 +230,8 @@ export function useDatepicker({
 
     if (
       focusedInput !== END_DATE &&
-      (!focusedDate || (focusedDate && !isSameMonth(date, focusedDate)))
+      (!focusedDate || (focusedDate && !isSameMonth(date, focusedDate))) &&
+      changeActiveMonthOnSelect
     ) {
       setActiveMonths(getInitialMonths(numberOfMonths, date))
     }


### PR DESCRIPTION
We have a use case where we do not want to change active months selection when selecting a date from the second month panel.  To avoid any breaking changes a new option was introduced `changeActiveMonthOnSelect`.
Please have a look at this small chang @tresko 